### PR TITLE
Use core standard definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 /_compiled/*.json
 /_compiled/*.xlsx
+*.swp
+*.swo

--- a/schema/360-giving-schema-extension.json
+++ b/schema/360-giving-schema-extension.json
@@ -65,7 +65,7 @@
             "description": "Classifications from Taxonomies which were available when the question was asked?",
             "type": "array",
             "items": {
-              "$ref": "#/definitions/DEI_Classification"
+              "$ref": "#/definitions/Classification"
             }
           },
           "dei_reply_status": {

--- a/schema/360-giving-schema-extension.json
+++ b/schema/360-giving-schema-extension.json
@@ -1,6 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
+    "Classification": {
+      "required": [
+        "vocabulary",
+	"code"
+      ]
+    },
     "DEI_Answer": {
       "type": "array",
       "items": {

--- a/schema/360-giving-schema-extension.json
+++ b/schema/360-giving-schema-extension.json
@@ -1,41 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
-    "DEI_Classification": {
-      "type": "object",
-      "properties": {
-          "vocabulary": {
-            "type": "string",
-            "description": "A vocabulary used for this classification.",
-            "title": "Vocabulary"
-          },
-          "code": {
-            "type": "string",
-            "description": "A codelist value in the chosen vocabulary.",
-            "title": "Code"
-          },
-          "title": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "The title of this classification.",
-            "title": "Title"
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "A description of this classification.",
-            "title": "Description"
-          }
-      },
-      "required": [
-        "vocabulary",
-        "code"
-      ]
-    },
     "DEI_Answer": {
       "type": "array",
       "items": {

--- a/schema/360-giving-schema-extension.json
+++ b/schema/360-giving-schema-extension.json
@@ -77,7 +77,7 @@
             "title": "Classification from Taxonomies",
             "type": "array",
             "items": {
-              "$ref": "#/definitions/DEI_Classification"
+              "$ref": "#/definitions/Classification"
             }
           },
           "classification_entered": {


### PR DESCRIPTION
This PR removes the DEI_Classification definition and instead replaces all instances of this object with a reference the Classifications object from the main 360Giving schema. This is because no new fields were added and the structure is identical.

The DEI_Classification definition did stipulate that the `vocabulary` and `code` fields were made required, which is a change from the original Classification definition. I have added this restraint in the extension to ensure this behaviour is maintained; it does this at the Definition level meaning all instances of Classification would be affected. I believe that, if required, this restriction can be modified to be applied to only the instances on fields added by this extension.