### PR TITLE
Schema adjustments

### DIFF
--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -1,34 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
-    "DeiResponse": {
-      "type": "object",
-      "title": "DEI Response",
-      "description": "A response to a DEI Application area, containing information such as the taxonomy codes selected and any lived experience or geography responses.",
-      "properties": {
-        "taxonomyCodes": {
-          "title": "Taxonomy Codes",
-          "description": "The Taxonomy Codes selected from the DEI Taxonomies. The value for these codes should be drawn from the Taxonomy Codes codelist.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "codelist": "taxonomyCodes.csv",
-            "openCodelist": false
-          },
-          "uniqueItems": true
-        },
-        "livedExperience": {
-          "type": "string",
-          "title": "Lived Experience",
-          "description": "A free text description of other types of lived experience that is not drawn from the Taxonomy."
-        },
-        "geography": {
-          "type": "string",
-          "title": "Geography",
-          "description": "A free text description that is not drawn from a vocabulary but instead relates to a particular geographical area."
-        }
-      }
-    },
     "DeiApplicationArea": {
       "type": "object",
       "title": "DEI Application Area",
@@ -68,41 +40,66 @@
           "description": "A free text field to include any additional details or rationales that may be important to this context."
         },
         "response": {
-          "$ref": "#/definitions/DeiResponse"
+          "type": "object",
+          "title": "DEI Response",
+          "description": "A response to a DEI Application area, containing information such as the taxonomy codes selected and any lived experience or geography responses.",
+          "properties": {
+            "taxonomyCodes": {
+              "title": "Taxonomy Codes",
+              "description": "The Taxonomy Codes selected from the DEI Taxonomies. The value for these codes should be drawn from the Taxonomy Codes codelist.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "codelist": "taxonomyCodes.csv",
+                "openCodelist": false
+              },
+              "uniqueItems": true
+            },
+            "livedExperience": {
+              "type": "string",
+              "title": "Lived Experience",
+              "description": "A free text description of other types of lived experience that is not drawn from the Taxonomy."
+            },
+            "geography": {
+              "type": "string",
+              "title": "Geography",
+              "description": "A free text description that is not drawn from a vocabulary but instead relates to a particular geographical area."
+            }
+          }
         }
       }
-    }
-  },
-  "properties": {
-    "deiDetails": {
-      "type": "object",
-      "title": "DEI Details",
-      "description": "The DEI Details for this grant. Contains information about separate application areas and the responses to them.",
-      "required": [
-        "leadership",
-        "mission",
-        "project"
-      ],
-      "properties": {
-        "deiVersion": {
-          "type": "string",
-          "title": "DEI Data Standard Version",
-          "description": "The version of the DEI Data Standard that this data uses e.g. 1.1",
-          "pattern": "^[1-9]+\\.[1-9]\\d*$"
-        },
-        "purposes": {
-          "type": "string",
-          "title": "Purposes",
-          "description": "The purposes of collecting this data."
-        },
-        "leadership": {
-          "$ref": "#/definitions/DeiApplicationArea"
-        },
-        "mission": {
-          "$ref": "#/definitions/DeiApplicationArea"
-        },
-        "project": {
-          "$ref": "#/definitions/DeiApplicationArea"
+    },
+    "properties": {
+      "deiDetails": {
+        "type": "object",
+        "title": "DEI Details",
+        "description": "The DEI Details for this grant. Contains information about separate application areas and the responses to them.",
+        "required": [
+          "leadership",
+          "mission",
+          "project"
+        ],
+        "properties": {
+          "deiVersion": {
+            "type": "string",
+            "title": "DEI Data Standard Version",
+            "description": "The version of the DEI Data Standard that this data uses e.g. 1.1",
+            "pattern": "^[1-9]+\\.[1-9]\\d*$"
+          },
+          "purposes": {
+            "type": "string",
+            "title": "Purposes",
+            "description": "The purposes of collecting this data."
+          },
+          "leadership": {
+            "$ref": "#/definitions/DeiApplicationArea"
+          },
+          "mission": {
+            "$ref": "#/definitions/DeiApplicationArea"
+          },
+          "project": {
+            "$ref": "#/definitions/DeiApplicationArea"
+          }
         }
       }
     }

--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -84,6 +84,12 @@
         "project"
       ],
       "properties": {
+	"deiVersion": {
+	  "type": "string",
+	  "title": "DEI Data Standard Version",
+	  "description": "The version of the DEI Data Standard that this data uses e.g. 1.1",
+	  "pattern": "^[1-9]+\\.[1-9]\\d*$"
+	},
         "purposes": {
           "type": "string",
           "title": "Purposes",

--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -20,19 +20,19 @@
         "livedExperience": {
           "type": "string",
           "title": "Lived Experience",
-          "description": "Description provided that are not drawn from a vocabulary but instead derived from lived experience"
+          "description": "A free text description of other types of lived experience that is not drawn from the Taxonomy."
         },
         "geography": {
           "type": "string",
           "title": "Geography",
-          "description": "Description provided that are not drawn from a vocabulary but instead drawn from Geography"
+          "description": "A free text description that is not drawn from a vocabulary but instead relates to a particular geographical area."
         }
       }
     },
     "DeiApplicationArea": {
       "type": "object",
       "title": "DEI Application Area",
-      "description": "A DEI Application area used to collect information about whether a particular question was asked, responded to, and additional information. It also contains the response information under the Response fields.",
+      "description": "A DEI application area used to collect information about whether a particular question was asked, responded to, and additional information. It also contains the response information under the Response fields.",
       "required": [
         "askedStatus"
       ],

--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
-    "DEIResponse": {
+    "DeiResponse": {
       "type": "object",
       "title": "DEI Response",
       "description": "A response to a DEI Application area, containing information such as the taxonomy codes selected and any lived experience or geography responses.",
@@ -29,7 +29,7 @@
         }
       }
     },
-    "DEIApplicationArea": {
+    "DeiApplicationArea": {
       "type": "object",
       "title": "DEI Application Area",
       "description": "A DEI Application area used to collect information about whether a particular question was asked, responded to, and additional information. It also contains the response information under the Response fields.",
@@ -68,11 +68,13 @@
           "description": "A free text field to include any additional details or rationales that may be important to this context."
         },
         "response": {
-          "$ref": "#/definitions/DEIResponse"
+          "$ref": "#/definitions/DeiResponse"
         }
       }
-    },
-    "DEIDetails": {
+    }
+  },
+  "properties": {
+    "deiDetails": {
       "type": "object",
       "title": "DEI Details",
       "description": "The DEI Details for this grant. Contains information about separate application areas and the responses to them.",
@@ -88,20 +90,15 @@
           "description": "The purposes of collecting this data."
         },
         "leadership": {
-          "$ref": "#/definitions/DEIApplicationArea"
+          "$ref": "#/definitions/DeiApplicationArea"
         },
         "mission": {
-          "$ref": "#/definitions/DEIApplicationArea"
+          "$ref": "#/definitions/DeiApplicationArea"
         },
         "project": {
-          "$ref": "#/definitions/DEIApplicationArea"
+          "$ref": "#/definitions/DeiApplicationArea"
         }
       }
-    }
-  },
-  "properties": {
-    "deiDetails": {
-      "$ref": "#/definitions/DEIDetails"
     }
   }
 }

--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -84,12 +84,12 @@
         "project"
       ],
       "properties": {
-	"deiVersion": {
-	  "type": "string",
-	  "title": "DEI Data Standard Version",
-	  "description": "The version of the DEI Data Standard that this data uses e.g. 1.1",
-	  "pattern": "^[1-9]+\\.[1-9]\\d*$"
-	},
+        "deiVersion": {
+          "type": "string",
+          "title": "DEI Data Standard Version",
+          "description": "The version of the DEI Data Standard that this data uses e.g. 1.1",
+          "pattern": "^[1-9]+\\.[1-9]\\d*$"
+        },
         "purposes": {
           "type": "string",
           "title": "Purposes",


### PR DESCRIPTION
This PR responds to some small things highlighted during the Normative Reference draft review:

* Object names have been adjusted for readability e.g. `DEIApplicationArea` -> `DeiApplicationArea`.
* The definition of `DEIDetails` has been removed and instead all its properties are added directly underneath the `deiDetails` field.
* Several property/object descriptions have been adjusted to reflect minor edits made in the Normative Draft.